### PR TITLE
Plugin: Copy Absolute Path

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18212,5 +18212,12 @@
     "author": "Jeffry",
     "description": "Collect related notes based on links/backlinks to provide focused context for external AI chatbots. Explore note relationships visually and export the bundle.",
     "repo": "shuxueshuxue/PackUp4AI"
+  },
+  {
+    "id": "copy-absolute-path",
+    "name": "Copy Absolute Path", 
+    "author": "dilakv",
+    "description": "Adds a context menu option to copy the absolute system path of files and folders. Supports English and Spanish automatically.",
+    "repo": "dilakv/obsidian-copy-absolute-path"
   }
 ]


### PR DESCRIPTION
## Plugin: Copy Absolute Path

**Repository**: https://github.com/dilakv/obsidian-copy-absolute-path
**Release**: v1.0.0

### Features:
- Context menu option to copy absolute system paths
- Small English/Spanish language support
- Command palette integration  
- Cross-platform compatibility
- Modern clipboard API with fallback support

### Testing:
Plugin has been tested on macOS and works correctly with both files and folders.

### Checklist:
- [x] Plugin follows Obsidian plugin guidelines
- [x] Release includes main.js and manifest.json
- [x] Plugin is functional and tested
- [x] README includes installation and usage instructions